### PR TITLE
Fixing mkdocs GitHub Action error: 

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,6 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: mkdocs.yml
+          EXTRA_PACKAGES: build-base
 
 #      - name: Set up Python 3.8
 #        uses: actions/setup-python@v2


### PR DESCRIPTION
To fix the error: `Could not build wheels for h5py`