### PR TITLE
Process controlled added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,12 @@ RUN apt-get update &&  \
     zip \
     unzip \
     tar \
-    ninja-build
+    ninja-build \
+    supervisor
+
+# setup supervisord
+RUN mkdir -p /var/log/supervisor
+ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # to speedup R package installations (try apt-cache search r-cran-remotes) https://datawookie.dev/blog/2019/01/docker-images-for-r-r-base-versus-r-apt/
 #RUN apt-get update && \

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ serve: $(NANOBOTDB)
 		rm -rf build/; \
 		$(NANOBOT) init; \
 	fi
-	python3 $(WORKSPACE)/tdt_api.py &
-	$(NANOBOT) serve
+	/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf
 
 .PHONY: clean
 clean:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ flask-cors
 # h5py 3.11 is not working
 h5py==3.10.0
 requests
+gunicorn
+git+https://github.com/coderanger/supervisor-stdout.git

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,33 @@
+[supervisord]
+nodaemon=true
+user=root
+logfile=/var/log/supervisor/supervisord.log
+logfile_maxbytes=50MB
+
+[program:nanobot]
+command=build/nanobot serve
+autostart=true
+autorestart=true
+startretries=5
+stdout_events_enabled=true
+stderr_events_enabled=true
+process_name=nanobot
+
+[program:gunicorn]
+command=gunicorn --chdir /tools --bind 0.0.0.0:5000 tdt_api:app --log-level=info
+autostart=true
+autorestart=true
+startretries=5
+stderr_logfile=/var/log/supervisor/%(program_name)s_stderr.log
+stderr_logfile_maxbytes=10MB
+stdout_logfile=/var/log/supervisor/%(program_name)s_stdout.log
+stdout_logfile_maxbytes=10MB
+process_name=%(program_name)s_%(process_num)02d
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[eventlistener:stdout]
+command = supervisor_stdout
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler


### PR DESCRIPTION
Related with issue: https://github.com/brain-bican/taxonomy-development-tools/issues/167

Docker was not able to gracefully shutdown both nanobot and python api.

`supervisord` process controller added to manage all processes. Python backend is deployed via `gunicorn`. 